### PR TITLE
Fix slack invitation link in header section

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,7 +26,7 @@ enableRobotsTXT = true
   gitlab = ""
   linkedin = ""
   mastodon = ""
-  slack = "https://ciudadrealtechhub.herokuapp.com/"
+  slack = "https://join.slack.com/t/ciudadrealtechhub/shared_invite/zt-1f985stgw-iggiiKRoQonMi7ITp6SRmw"
   stackoverflow = ""
   rss = ""
   # choose a background color from any on this page:


### PR DESCRIPTION
Fix slack invitation link to avoid to use the old herokuapp.
